### PR TITLE
Add VCacheable instance for Float

### DIFF
--- a/hsrc_lib/Database/VCache/VCacheable.hs
+++ b/hsrc_lib/Database/VCache/VCacheable.hs
@@ -34,7 +34,7 @@ instance VCacheable Integer where
 
 instance VCacheable Float where
     get = encodeFloat <$> get <*> get
-    put f =
+    put f = do
         let (a, b) = decodeFloat f
         put a
         put b

--- a/hsrc_lib/Database/VCache/VCacheable.hs
+++ b/hsrc_lib/Database/VCache/VCacheable.hs
@@ -32,6 +32,13 @@ instance VCacheable Integer where
     {-# INLINE get #-}
     {-# INLINE put #-}
 
+instance VCacheable Float where
+    get = encodeFloat <$> get <*> get
+    put f =
+        let (a, b) = decodeFloat f
+        put a
+        put b
+
 instance VCacheable Bool where
     get = getWord8 >>= \ n -> case n of
         0 -> return False


### PR DESCRIPTION
This commit adds encoding and decoding functions for Floats to allow them to be stored in VCache.